### PR TITLE
fix(deps): bump crossbeam-epoch and anyhow to clear RUSTSEC advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Problem

The `Security audit` CI job (`cargo audit`) fails on `main` and therefore on every open PR, including the Renovate PRs #46 and #48. Because `cargo audit` fetches the advisory DB live, this started failing without any code change on our side.

Reproduced locally on the current `main`:

- **RUSTSEC-2026-0204** - `crossbeam-epoch` 0.9.18, invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`. Classed as a *vulnerability*, so it fails the job. Requires `>=0.9.20`.
- **RUSTSEC-2026-0190** - `anyhow` 1.0.102, unsoundness in `Error::downcast_mut()`. Only a warning, non-fatal, but cleared here too.

Both crates are transitive-only (`crossbeam-epoch` via `ignore` and `rayon`), so no manifest change is needed.

## Change

Lockfile-only bumps:

- `crossbeam-epoch` 0.9.18 -> 0.9.20
- `anyhow` 1.0.102 -> 1.0.104

## Verification

- `cargo audit` - clean, no vulnerabilities and no warnings
- `cargo fmt --check` - clean
- `cargo clippy --all-targets --all-features -- -D warnings` - clean
- `cargo test` - 39 passed, 0 failed

## Note

This unblocks #46 and #48, whose `Security audit` failures were caused by this and not by anything in those PRs (both only change GitHub Actions pin SHAs).