### PR TITLE
fix: recognize LINT directives in extensionless Makefiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Wall-clock time to lint a 30k-line diff or scan all directives in a synthetic 50
 | `.cpp` | `.gd` | `.ksh` | `.prolog` | `.svg` | `.zsh` |
 
 **Special files**: `Dockerfile{,.*}`, `.gitignore`, `go.mod`, `Makefile` / `makefile` / `GNUmakefile`
-<!-- LINT.ThenChange("src/comment/extract.rs") -->
+<!-- LINT.ThenChange(["src/comment/extract.rs", "src/directive/parse.rs"]) -->
 
 ## Recommended AGENTS.md / CLAUDE.md
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Wall-clock time to lint a 30k-line diff or scan all directives in a synthetic 50
 | `.conf` | `.fsx` | `.jsx` | `.pro` | `.svelte` | `.zig` |
 | `.cpp` | `.gd` | `.ksh` | `.prolog` | `.svg` | `.zsh` |
 
-**Special files**: `Dockerfile{,.*}`, `.gitignore`, `go.mod`
+**Special files**: `Dockerfile{,.*}`, `.gitignore`, `go.mod`, `Makefile` / `makefile` / `GNUmakefile`
 <!-- LINT.ThenChange("src/comment/extract.rs") -->
 
 ## Recommended AGENTS.md / CLAUDE.md

--- a/src/comment/extract.rs
+++ b/src/comment/extract.rs
@@ -378,7 +378,7 @@ fn clean_block_comment(raw: &str) -> String {
             let trimmed = line.trim_start();
             if let Some(rest) = trimmed.strip_prefix("* ") {
                 rest
-            } else if trimmed.strip_prefix('*').is_some_and(|s| s.is_empty()) {
+            } else if trimmed.strip_prefix('*').is_some_and(str::is_empty) {
                 ""
             } else if let Some(rest) = trimmed.strip_prefix('*') {
                 rest
@@ -433,7 +433,7 @@ fn extract_apostrophe_style(content: &str) -> Vec<Comment> {
         let trimmed = line.trim_start();
         if trimmed.len() >= 3 && trimmed[..3].eq_ignore_ascii_case("rem") {
             let after = trimmed[3..].chars().next();
-            if after.is_none() || after.is_some_and(|c| c.is_whitespace()) {
+            if after.is_none() || after.is_some_and(char::is_whitespace) {
                 comments.push(Comment {
                     start_line: idx + 1,
                     text: trimmed[3..].to_string(),

--- a/src/comment/extract.rs
+++ b/src/comment/extract.rs
@@ -84,7 +84,8 @@ const HTML_STYLE_EXTS: &[&str] = &[
     "html", "htm", "xml", "svg", "md", "vue", "svelte", "xsl", "xslt", "jsp", "erb",
 ];
 // Special filenames: "dockerfile" matches Dockerfile and Dockerfile.* variants
-// (see effective_extension() in directive/parse.rs), "gitignore" matches .gitignore.
+// (see effective_extension() in directive/parse.rs), "gitignore" matches .gitignore,
+// "mk" matches Makefile, makefile, and GNUmakefile (extensionless).
 // LINT.ThenChange("../../README.md#supported-languages")
 
 /// Extract all comments from `content`, using the comment style implied by `file_ext`
@@ -756,6 +757,27 @@ mod tests {
         ext: &str,
     ) {
         assert_eq!(extract_comments("# note\ncode\n", ext), vec![c(1, " note")]);
+    }
+
+    #[test]
+    fn makefile_url_does_not_defeat_hash_directives() {
+        // Regression: a Makefile (mapped to "mk") containing a `//` URL must still
+        // extract its `#` LINT directives. The old unknown-ext branch tried C-style
+        // first, matched the `//` in the URL, and never fell back to hash style.
+        let content = "URL = https://example.com/x\n# LINT.Label(foo)\nVAR = 1\n# LINT.EndLabel\n";
+        let comments = extract_comments(content, "mk");
+        assert!(
+            comments.iter().any(|c| c.text.contains("LINT.Label(foo)")),
+            "hash directives must be extracted despite // in URL: {:?}",
+            comments
+        );
+        assert!(
+            comments.iter().any(|c| c.text.contains("LINT.EndLabel")),
+            "hash directives must be extracted despite // in URL: {:?}",
+            comments
+        );
+        // The URL line is not a comment and must not appear.
+        assert!(!comments.iter().any(|c| c.text.contains("https")));
     }
 
     #[rstest]

--- a/src/directive/parse.rs
+++ b/src/directive/parse.rs
@@ -61,6 +61,10 @@ fn effective_extension(file_path: &str) -> &str {
     if filename.eq_ignore_ascii_case("go.mod") {
         return "go.mod";
     }
+    // "Makefile", "makefile", "GNUmakefile" (no extension) use # comments
+    if filename.eq_ignore_ascii_case("makefile") || filename.eq_ignore_ascii_case("gnumakefile") {
+        return "mk";
+    }
     filename.rsplit('.').next().unwrap_or("")
 }
 
@@ -705,6 +709,30 @@ mod tests {
     fn dockerfile_variant_parses_hash_comments() {
         let content = "# LINT.IfChange\nRUN echo hi\n# LINT.ThenChange(\"other.py\")\n";
         let directives = parse_directives_from_content(content, "Dockerfile.prod").unwrap();
+        assert_eq!(then_targets(directives), vec!["other.py"]);
+    }
+
+    #[rstest]
+    #[case("Makefile", "mk")]
+    #[case("makefile", "mk")]
+    #[case("GNUmakefile", "mk")]
+    #[case("gnumakefile", "mk")]
+    #[case("MAKEFILE", "mk")]
+    #[case("path/to/Makefile", "mk")]
+    #[case("path/to/GNUmakefile", "mk")]
+    fn effective_extension_makefile_variants(#[case] path: &str, #[case] expected: &str) {
+        assert_eq!(effective_extension(path), expected);
+    }
+
+    #[rstest]
+    #[case("Makefile")]
+    #[case("makefile")]
+    #[case("GNUmakefile")]
+    fn makefile_parses_hash_comments_despite_url(#[case] filename: &str) {
+        // Regression: a `//` in a URL must not defeat hash-style extraction of
+        // `#` LINT directives in an extensionless Makefile.
+        let content = "URL = https://example.com/x\n# LINT.IfChange\nVAR = 1\n# LINT.ThenChange(\"other.py\")\n";
+        let directives = parse_directives_from_content(content, filename).unwrap();
         assert_eq!(then_targets(directives), vec!["other.py"]);
     }
 }

--- a/src/directive/parse.rs
+++ b/src/directive/parse.rs
@@ -47,7 +47,7 @@ pub fn parse_file_directives(file_path: &str) -> Result<Vec<Directive>, Directiv
 fn effective_extension(file_path: &str) -> &str {
     let filename = std::path::Path::new(file_path)
         .file_name()
-        .and_then(|s| s.to_str())
+        .and_then(std::ffi::OsStr::to_str)
         .unwrap_or(file_path);
     let filename_lower = filename.as_bytes();
     // "Dockerfile" or "Dockerfile.something"


### PR DESCRIPTION
Extensionless `Makefile`s never had their `#`-comment `LINT.*` directives recognized. With no extension, they fell through to the unknown-extension path, which tries C-style comments first and only falls back to hash style if C-style finds nothing. Any Makefile with a `//` in a URL (e.g. `URL = https://...`) gave C-style a non-empty result, so hash extraction never ran and the directives were invisible.

Fix: map `Makefile`, `makefile`, and `GNUmakefile` to the existing `mk` hash-style extension in `effective_extension()`, the same special-filename path already used for `Dockerfile` and `go.mod`. Tests cover the URL regression at both the extraction and the parse layer, and the README special-files list is updated (its `LINT.ThenChange` guard now points at both source files).

Also folds in three redundant-closure cleanups SonarQube flagged in the touched files (`OsStr::to_str`, `str::is_empty`, `char::is_whitespace`).
